### PR TITLE
Use correct audit rules for RHEL 7.

### DIFF
--- a/roles/harden/tasks/main.yml
+++ b/roles/harden/tasks/main.yml
@@ -13,6 +13,6 @@
   when: ansible_distribution == "CentOS"
 
 - name: Copy RHEL Audit Rules
-  copy: src=centos7-audit.rules
+  copy: src=rhel7-audit.rules
         dest=/etc/audit/rules.d/rhel7-audit.rules
   when: ansible_distribution == "RHEL"


### PR DESCRIPTION
This change makes it so that the `harden` role will copy
the correct rules into place for RHEL7.
